### PR TITLE
Add concurrency control to scheduled workflows

### DIFF
--- a/.github/workflows/nightly-decision-desk.yml
+++ b/.github/workflows/nightly-decision-desk.yml
@@ -3,6 +3,10 @@
 
 name: "Nightly Decision Desk"
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 on:
   schedule:
     - cron: '0 21 * * *'  # 9 PM UTC = 9 PM GMT

--- a/.github/workflows/weekly-cost-rollup.yml
+++ b/.github/workflows/weekly-cost-rollup.yml
@@ -3,6 +3,10 @@
 
 name: "Weekly Cost Rollup"
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 on:
   schedule:
     - cron: '0 18 * * 0'  # 6 PM UTC every Sunday


### PR DESCRIPTION
## Summary\n- add workflow-level concurrency to nightly decision desk and weekly cost rollup\n\n## Testing\n- gh workflow run nightly-decision-desk.yml (x2)\n- gh workflow run weekly-cost-rollup.yml (x2)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 3 failed — [View all](https://hub.continue.dev/inbox/pr/zebadee2kk/control-tower/40?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->