### PR TITLE
feat: wire Python layer into enhanced-decision-desk GitHub Actions workflow

### DIFF
--- a/.github/workflows/enhanced-decision-desk.yml
+++ b/.github/workflows/enhanced-decision-desk.yml
@@ -1,0 +1,46 @@
+name: "Enhanced Decision Desk"
+
+# Runs nightly at 21:10 UTC (10 min after the existing JS Decision Desk)
+# so there's no race condition when closing old issues.
+# Can also be triggered manually via workflow_dispatch.
+
+on:
+  schedule:
+    - cron: '10 21 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  enhanced-decision-desk:
+    name: Run Enhanced Decision Desk
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run Enhanced Decision Desk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OLLAMA_HOST: ${{ secrets.OLLAMA_HOST }}
+          AI_COST_TRACKER_URL: ${{ secrets.AI_COST_TRACKER_URL }}
+          AI_COST_TRACKER_TOKEN: ${{ secrets.AI_COST_TRACKER_TOKEN }}
+        run: python -m src.run_enhanced_desk

--- a/src/decision_desk.py
+++ b/src/decision_desk.py
@@ -258,6 +258,63 @@ class DecisionDesk:
         ]
         return "\n".join(lines)
 
+    # ------------------------------------------------------------------
+    # GitHub issue posting
+    # ------------------------------------------------------------------
+
+    _ISSUE_LABEL = "enhanced-decision-desk"
+    _ISSUE_TITLE_PREFIX = "Enhanced Decision Desk"
+
+    def post_report(self, body: str) -> Any:
+        """
+        Close any previously open Enhanced Decision Desk issues, then create
+        a new one with ``body`` as its content.
+
+        The issue is tagged with ``enhanced-decision-desk`` and
+        ``state:awaiting-decision`` labels (the label must exist on the repo).
+        Returns the newly created ``github.Issue.Issue`` object.
+        """
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+
+        # Close old enhanced desk issues
+        old_issues = list(
+            self.repo.get_issues(
+                state="open",
+                labels=[self._ISSUE_LABEL],
+            )
+        )
+        for old in old_issues:
+            if old.title.startswith(self._ISSUE_TITLE_PREFIX) and not old.pull_request:
+                old.edit(state="closed", state_reason="completed")
+                logger.info("Closed old Enhanced Decision Desk #%s", old.number)
+
+        # Ensure the label exists (create if missing)
+        self._ensure_label(
+            self._ISSUE_LABEL,
+            color="0075ca",
+            description="Auto-generated enhanced decision desk issue",
+        )
+
+        # Create new issue
+        new_issue = self.repo.create_issue(
+            title=f"{self._ISSUE_TITLE_PREFIX} {today}",
+            body=body,
+            labels=[self._ISSUE_LABEL, "state:awaiting-decision"],
+        )
+        logger.info("Created Enhanced Decision Desk issue #%s", new_issue.number)
+        return new_issue
+
+    def _ensure_label(self, name: str, color: str, description: str) -> None:
+        """Create a label on the repo if it doesn't already exist."""
+        try:
+            self.repo.get_label(name)
+        except Exception:  # noqa: BLE001 — GithubException subclass
+            try:
+                self.repo.create_label(name=name, color=color, description=description)
+                logger.info("Created label '%s'", name)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Could not create label '%s': %s", name, exc)
+
 
 # ---------------------------------------------------------------------------
 # CLI entry point

--- a/src/run_enhanced_desk.py
+++ b/src/run_enhanced_desk.py
@@ -1,0 +1,185 @@
+"""
+run_enhanced_desk.py — GitHub Actions entry point for the Enhanced Decision Desk.
+
+Workflow:
+  1. Fetch all open issues from the repo
+  2. Run AI scoring on issues needing attention (approval + blocked + high-priority)
+  3. Render an enhanced Markdown report combining triage sections and AI scores
+  4. Close the previous Enhanced Decision Desk issue, create a new one
+  5. Log token usage to ai-cost-tracker (if configured)
+
+Environment variables (set as GitHub Actions secrets / env):
+  GITHUB_TOKEN            — required, write access to the repo
+  GITHUB_REPOSITORY       — set automatically by Actions (owner/repo)
+  ANTHROPIC_API_KEY       — for claude-haiku scoring (falls back to heuristic)
+  OLLAMA_HOST             — for local model urgency classification
+  AI_COST_TRACKER_URL     — optional, for cost logging
+  AI_COST_TRACKER_TOKEN   — optional, for cost logging
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+from dotenv import load_dotenv
+from github import Github
+
+load_dotenv(os.path.expanduser("~/.env"), override=True)
+
+# Local imports — path is set by the workflow's PYTHONPATH
+from src.ai_analysis import score_issues_batch  # noqa: E402
+from src.decision_desk import DecisionDesk  # noqa: E402
+from src.integrations.cost_tracker import CostTrackerClient  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+# How many issues to score with AI (caps cost; remainder still appears in report)
+_AI_SCORE_LIMIT = 15
+
+
+# ---------------------------------------------------------------------------
+# Enhanced Markdown renderer
+# ---------------------------------------------------------------------------
+
+def _render_ai_section(scored: list[dict[str, Any]]) -> list[str]:
+    """Render the AI scoring table as Markdown."""
+    if not scored:
+        return []
+
+    lines = [
+        "### 🤖 AI Priority Scoring",
+        "",
+        "| # | Score | Urgency | Summary | Action |",
+        "|---|-------|---------|---------|--------|",
+    ]
+    for s in scored:
+        urgency_emoji = {"critical": "🔴", "high": "🟠", "medium": "🟡", "low": "🟢"}.get(
+            s["urgency"], "⚪"
+        )
+        num = s["issue_number"]
+        score = s["priority_score"]
+        urgency = f"{urgency_emoji} {s['urgency']}"
+        summary = s["one_line_summary"][:60]
+        action = s["recommended_action"][:60]
+        model_note = "" if s["ai_model"] != "heuristic" else " ⚠️"
+        lines.append(f"| #{num}{model_note} | **{score}** | {urgency} | {summary} | {action} |")
+
+    lines.append("")
+    lines.append(
+        "_⚠️ = heuristic score (AI unavailable for this issue). "
+        "Scores are 0-100; higher = more urgent._"
+    )
+    lines.append("")
+    return lines
+
+
+def render_enhanced_report(
+    report: dict[str, Any],
+    desk: DecisionDesk,
+    scored: list[dict[str, Any]],
+) -> str:
+    """
+    Combine the standard Decision Desk Markdown with the AI scoring table.
+    """
+    # Start with the standard report body
+    base_md = desk.render_markdown(report)
+
+    # Append AI section
+    ai_lines = _render_ai_section(scored)
+    if ai_lines:
+        ai_block = "\n".join(["", "---", ""] + ai_lines)
+        return base_md + ai_block
+
+    return base_md
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    token = os.getenv("GITHUB_TOKEN")
+    repo_name = os.getenv("GITHUB_REPOSITORY", "zebadee2kk/control-tower")
+
+    if not token:
+        logger.error("GITHUB_TOKEN not set — cannot proceed")
+        sys.exit(1)
+
+    logger.info("Starting Enhanced Decision Desk for %s", repo_name)
+
+    # --- Build report ---
+    desk = DecisionDesk(Github(token), repo_name)
+    report = desk.build_report()
+
+    summary = report["summary"]
+    logger.info(
+        "Report: %d approval, %d blocked, %d high-pri, %d stale",
+        summary["needs_approval_count"],
+        summary["blocked_count"],
+        summary["high_priority_count"],
+        summary["stale_count"],
+    )
+
+    # --- AI scoring on the issues most needing attention ---
+    # Score needs-approval + blocked + high-priority (de-duplicated)
+    to_score: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for issue in (
+        report["needs_approval"] + report["blocked"] + report["high_priority"]
+    ):
+        if issue["number"] not in seen:
+            seen.add(issue["number"])
+            to_score.append(issue)
+
+    if to_score:
+        logger.info("Running AI scoring on %d issues (cap %d)", len(to_score), _AI_SCORE_LIMIT)
+        scored = score_issues_batch(to_score, max_issues=_AI_SCORE_LIMIT)
+    else:
+        logger.info("No issues to score")
+        scored = []
+
+    # --- Render enhanced report ---
+    body = render_enhanced_report(report, desk, scored)
+
+    # --- Post to GitHub ---
+    new_issue = desk.post_report(body)
+    logger.info("Enhanced Decision Desk posted: %s", new_issue.html_url)
+
+    # --- Log costs (optional, graceful degradation) ---
+    tracker = CostTrackerClient()
+    if tracker.enabled and scored:
+        # Estimate: each scored issue used ~400 tokens via claude-haiku + ~50 via Ollama
+        ai_issues = [s for s in scored if s["ai_model"] != "heuristic"]
+        ollama_issues = [s for s in scored if s["ai_model"] == "heuristic"]
+
+        if ai_issues:
+            tokens = len(ai_issues) * 400
+            cost = tokens * 0.00000025  # claude-haiku input ~$0.25 / 1M tokens
+            tracker.log_usage(
+                provider="anthropic",
+                model="claude-haiku-4-5-20251001",
+                tokens=tokens,
+                cost=cost,
+                context={"workflow": "enhanced-decision-desk", "issues_scored": len(ai_issues)},
+            )
+
+        if ollama_issues:
+            tracker.log_usage(
+                provider="ollama",
+                model="qwen2.5-coder:1.5b",
+                tokens=len(ollama_issues) * 50,
+                cost=0.0,
+                context={"workflow": "enhanced-decision-desk", "issues_scored": len(ollama_issues)},
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_post_report.py
+++ b/tests/unit/test_post_report.py
@@ -1,0 +1,254 @@
+"""
+Unit tests for DecisionDesk.post_report() and run_enhanced_desk rendering.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.decision_desk import DecisionDesk
+from src.run_enhanced_desk import _render_ai_section, render_enhanced_report
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_desk(open_issues: list | None = None) -> tuple[DecisionDesk, MagicMock]:
+    """Return a DecisionDesk wired to a mock repo, plus the mock repo."""
+    mock_gh = MagicMock()
+    mock_repo = MagicMock()
+    mock_repo.get_issues.return_value = open_issues or []
+    mock_repo.get_label.side_effect = Exception("not found")
+    mock_repo.create_label.return_value = MagicMock()
+    mock_gh.get_repo.return_value = mock_repo
+    desk = DecisionDesk(mock_gh, "owner/repo")
+    return desk, mock_repo
+
+
+@pytest.fixture
+def sample_report() -> dict[str, Any]:
+    now = datetime.now(tz=UTC).isoformat()
+    return {
+        "generated_at": now,
+        "repo": "owner/repo",
+        "needs_approval": [
+            {
+                "number": 10,
+                "title": "Approve this feature",
+                "labels": ["gate:needs-approval"],
+                "updated_at": now,
+                "body": "",
+                "url": "https://github.com/owner/repo/issues/10",
+                "assignees": [],
+                "state": "open",
+                "created_at": now,
+            }
+        ],
+        "blocked": [],
+        "high_priority": [],
+        "stale": [],
+        "summary": {
+            "needs_approval_count": 1,
+            "blocked_count": 0,
+            "high_priority_count": 0,
+            "stale_count": 0,
+        },
+    }
+
+
+@pytest.fixture
+def sample_scored() -> list[dict[str, Any]]:
+    return [
+        {
+            "issue_number": 10,
+            "priority_score": 82,
+            "urgency": "high",
+            "one_line_summary": "Feature approval blocking team velocity",
+            "recommended_action": "Review and approve before sprint end",
+            "reasoning": "Blocking multiple developers.",
+            "ai_model": "claude-haiku-4-5-20251001",
+            "error": None,
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# DecisionDesk.post_report()
+# ---------------------------------------------------------------------------
+
+class TestPostReport:
+    def test_creates_new_issue(self) -> None:
+        desk, mock_repo = _make_desk()
+        mock_new = MagicMock()
+        mock_new.number = 99
+        mock_new.html_url = "https://github.com/owner/repo/issues/99"
+        mock_repo.create_issue.return_value = mock_new
+
+        result = desk.post_report("## Report body")
+
+        mock_repo.create_issue.assert_called_once()
+        call_kwargs = mock_repo.create_issue.call_args.kwargs
+        assert "Enhanced Decision Desk" in call_kwargs["title"]
+        assert "## Report body" in call_kwargs["body"]
+        assert result == mock_new
+
+    def test_closes_old_enhanced_desk_issues(self) -> None:
+        """Any previously open Enhanced Decision Desk issues are closed."""
+        old_issue = MagicMock()
+        old_issue.number = 55
+        old_issue.title = "Enhanced Decision Desk 2026-03-06"
+        old_issue.pull_request = None
+
+        desk, mock_repo = _make_desk(open_issues=[old_issue])
+        mock_repo.create_issue.return_value = MagicMock(number=56, html_url="...")
+
+        desk.post_report("body")
+
+        old_issue.edit.assert_called_once_with(state="closed", state_reason="completed")
+
+    def test_does_not_close_unrelated_issues(self) -> None:
+        """Issues without the enhanced-decision-desk title prefix are left alone."""
+        unrelated = MagicMock()
+        unrelated.number = 30
+        unrelated.title = "Regular bug report"
+        unrelated.pull_request = None
+
+        desk, mock_repo = _make_desk(open_issues=[unrelated])
+        mock_repo.create_issue.return_value = MagicMock(number=31, html_url="...")
+
+        desk.post_report("body")
+
+        unrelated.edit.assert_not_called()
+
+    def test_does_not_close_pull_requests(self) -> None:
+        """PRs returned by the issues API are never edited."""
+        pr = MagicMock()
+        pr.number = 40
+        pr.title = "Enhanced Decision Desk 2026-03-05"
+        pr.pull_request = MagicMock()  # marks it as a PR
+
+        desk, mock_repo = _make_desk(open_issues=[pr])
+        mock_repo.create_issue.return_value = MagicMock(number=41, html_url="...")
+
+        desk.post_report("body")
+
+        pr.edit.assert_not_called()
+
+    def test_creates_label_if_missing(self) -> None:
+        """If the enhanced-decision-desk label doesn't exist, it is created."""
+        desk, mock_repo = _make_desk()
+        mock_repo.get_label.side_effect = Exception("not found")
+        mock_repo.create_issue.return_value = MagicMock(number=1, html_url="...")
+
+        desk.post_report("body")
+
+        mock_repo.create_label.assert_called_once_with(
+            name="enhanced-decision-desk",
+            color="0075ca",
+            description="Auto-generated enhanced decision desk issue",
+        )
+
+    def test_skips_label_creation_if_already_exists(self) -> None:
+        """If the label already exists, create_label is not called."""
+        desk, mock_repo = _make_desk()
+        mock_repo.get_label.side_effect = None  # no exception = label exists
+        mock_repo.get_label.return_value = MagicMock()
+        mock_repo.create_issue.return_value = MagicMock(number=1, html_url="...")
+
+        desk.post_report("body")
+
+        mock_repo.create_label.assert_not_called()
+
+    def test_title_contains_todays_date(self) -> None:
+        desk, mock_repo = _make_desk()
+        mock_repo.create_issue.return_value = MagicMock(number=1, html_url="...")
+
+        desk.post_report("body")
+
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        title = mock_repo.create_issue.call_args.kwargs["title"]
+        assert today in title
+
+
+# ---------------------------------------------------------------------------
+# _render_ai_section
+# ---------------------------------------------------------------------------
+
+class TestRenderAiSection:
+    def test_empty_scored_returns_empty(self) -> None:
+        assert _render_ai_section([]) == []
+
+    def test_contains_issue_number(self, sample_scored: list[dict]) -> None:
+        lines = _render_ai_section(sample_scored)
+        combined = "\n".join(lines)
+        assert "#10" in combined
+
+    def test_contains_priority_score(self, sample_scored: list[dict]) -> None:
+        lines = _render_ai_section(sample_scored)
+        combined = "\n".join(lines)
+        assert "82" in combined
+
+    def test_urgency_emojis(self, sample_scored: list[dict]) -> None:
+        for urgency, emoji in [
+            ("critical", "🔴"), ("high", "🟠"), ("medium", "🟡"), ("low", "🟢")
+        ]:
+            scored = [{**sample_scored[0], "urgency": urgency}]
+            lines = _render_ai_section(scored)
+            combined = "\n".join(lines)
+            assert emoji in combined
+
+    def test_heuristic_fallback_marked(self, sample_scored: list[dict]) -> None:
+        heuristic = [{**sample_scored[0], "ai_model": "heuristic"}]
+        lines = _render_ai_section(heuristic)
+        combined = "\n".join(lines)
+        assert "⚠️" in combined
+
+    def test_table_headers_present(self, sample_scored: list[dict]) -> None:
+        lines = _render_ai_section(sample_scored)
+        combined = "\n".join(lines)
+        assert "Score" in combined
+        assert "Urgency" in combined
+        assert "Summary" in combined
+        assert "Action" in combined
+
+
+# ---------------------------------------------------------------------------
+# render_enhanced_report
+# ---------------------------------------------------------------------------
+
+class TestRenderEnhancedReport:
+    def test_contains_base_report_sections(
+        self,
+        sample_report: dict,
+        sample_scored: list[dict],
+    ) -> None:
+        desk, _ = _make_desk()
+        md = render_enhanced_report(sample_report, desk, sample_scored)
+        assert "Needs Approval" in md
+        assert "Blocked" in md
+        assert "High Priority" in md
+
+    def test_contains_ai_section_when_scored(
+        self,
+        sample_report: dict,
+        sample_scored: list[dict],
+    ) -> None:
+        desk, _ = _make_desk()
+        md = render_enhanced_report(sample_report, desk, sample_scored)
+        assert "AI Priority Scoring" in md
+        assert "#10" in md
+
+    def test_no_ai_section_when_no_scores(self, sample_report: dict) -> None:
+        desk, _ = _make_desk()
+        md = render_enhanced_report(sample_report, desk, [])
+        assert "AI Priority Scoring" not in md
+
+    def test_is_string(self, sample_report: dict, sample_scored: list[dict]) -> None:
+        desk, _ = _make_desk()
+        result = render_enhanced_report(sample_report, desk, sample_scored)
+        assert isinstance(result, str)
+        assert len(result) > 0


### PR DESCRIPTION
## Summary

- **`DecisionDesk.post_report()`** — closes any previous Enhanced Decision Desk issues, auto-creates the `enhanced-decision-desk` label if absent, then posts the new report as a GitHub issue
- **`src/run_enhanced_desk.py`** — the Actions entry point: builds the triage report, runs AI scoring on approval/blocked/high-priority issues, renders enhanced Markdown with an AI priority table, posts to GitHub, and logs costs to ai-cost-tracker
- **`.github/workflows/enhanced-decision-desk.yml`** — runs nightly at 21:10 UTC (10 min after the existing JS workflow to avoid race conditions); also triggerable manually via `workflow_dispatch`
- **`tests/unit/test_post_report.py`** — 17 new unit tests covering `post_report()` and all rendering paths

## What this looks like

Every night at 21:10 UTC a new issue titled **Enhanced Decision Desk YYYY-MM-DD** will appear, containing:
- The standard triage sections (needs approval, blocked, high-priority, stale)
- An AI Priority Scoring table with a 0-100 score, urgency emoji, one-line summary, and recommended action for each key issue
- Heuristic fallback scores (marked ⚠️) if AI is temporarily unavailable

## Architecture

- Existing Phase 2 JS workflows are **completely untouched**
- Secrets needed: `ANTHROPIC_API_KEY` (already in repo secrets after Phase 3A), `OLLAMA_HOST` (optional — falls back gracefully)
- `AI_COST_TRACKER_URL` / `AI_COST_TRACKER_TOKEN` optional — no-op if not set

## Test plan

- [x] 82 unit tests passing, 81% coverage
- [x] `ruff check` clean
- [ ] CI will run on this PR automatically
- [ ] After merge: trigger manually via `workflow_dispatch` to verify the issue posts correctly before first nightly run

🤖 Generated with Claude