### PR TITLE
fix: guard against empty OLLAMA_HOST in _call_ollama

### DIFF
--- a/src/ai_analysis.py
+++ b/src/ai_analysis.py
@@ -76,8 +76,11 @@ def _call_ollama(prompt: str, model: str = OLLAMA_MODEL, timeout: int = 30) -> s
     Call the local Ollama API (non-streaming).
 
     Returns the text content of the response, or raises ``RuntimeError``
-    if the request fails.
+    if the request fails or ``OLLAMA_HOST`` is not configured.
     """
+    if not OLLAMA_HOST:
+        raise RuntimeError("OLLAMA_HOST is not configured — skipping Ollama call")
+
     payload = json.dumps(
         {"model": model, "prompt": prompt, "stream": False}
     ).encode()

--- a/tests/unit/test_ai_analysis.py
+++ b/tests/unit/test_ai_analysis.py
@@ -12,7 +12,9 @@ from unittest.mock import patch
 
 import pytest
 
+import src.ai_analysis as ai_analysis
 from src.ai_analysis import (
+    _call_ollama,
     _heuristic_score,
     classify_urgency,
     score_issue,
@@ -69,6 +71,35 @@ def unlabelled_issue() -> dict[str, Any]:
         "body": "The search endpoint takes 3s to respond.",
         "updated_at": "2026-02-28T09:00:00+00:00",
     }
+
+
+# ---------------------------------------------------------------------------
+# _call_ollama — empty/missing OLLAMA_HOST guard
+# ---------------------------------------------------------------------------
+
+class TestCallOllamaHostGuard:
+    def test_raises_runtime_error_when_host_is_empty_string(self) -> None:
+        """Regression: empty OLLAMA_HOST must raise RuntimeError (not ValueError)
+        so that classify_urgency's except block catches it and falls back to heuristic."""
+        original = ai_analysis.OLLAMA_HOST
+        try:
+            ai_analysis.OLLAMA_HOST = ""
+            with pytest.raises(RuntimeError, match="OLLAMA_HOST is not configured"):
+                _call_ollama("test prompt")
+        finally:
+            ai_analysis.OLLAMA_HOST = original
+
+    def test_classify_urgency_falls_back_when_host_is_empty(
+        self, critical_issue: dict[str, Any]
+    ) -> None:
+        """End-to-end: empty OLLAMA_HOST → heuristic urgency, no crash."""
+        original = ai_analysis.OLLAMA_HOST
+        try:
+            ai_analysis.OLLAMA_HOST = ""
+            result = classify_urgency(critical_issue)
+        finally:
+            ai_analysis.OLLAMA_HOST = original
+        assert result == "critical"  # heuristic for priority:critical
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fixes a runtime crash in the Enhanced Decision Desk workflow when `OLLAMA_HOST` is not configured as a GitHub Actions secret.

## Root cause

When `OLLAMA_HOST` is set to an empty string (the env var exists but has no value), `os.getenv("OLLAMA_HOST", default)` returns `""` — the default is only used when the key is **absent**. This caused the URL to be constructed as `"/api/generate"`, which raises a `ValueError` from Python's urllib *before* the request is even attempted. The `except RuntimeError` block in `classify_urgency` never fired, so the heuristic fallback never engaged.

## Fix

Added a two-line guard at the top of `_call_ollama` that raises `RuntimeError` immediately if `OLLAMA_HOST` is falsy. `classify_urgency` already catches `RuntimeError` and falls back to label-based heuristic scoring — this just ensures that path is reachable.

## Tests

- `test_raises_runtime_error_when_host_is_empty_string` — unit test on `_call_ollama` directly
- `test_classify_urgency_falls_back_when_host_is_empty` — end-to-end: empty host → heuristic urgency, no crash

84 tests, all passing.

## Verified

First workflow_dispatch run (Run #1) confirmed the exact traceback this fixes. Once merged, re-trigger workflow_dispatch to confirm clean run.