### PR TITLE
feat: Phase 3B — portfolio health integration in Enhanced Decision Desk

### DIFF
--- a/src/integrations/portfolio_scanner.py
+++ b/src/integrations/portfolio_scanner.py
@@ -1,0 +1,311 @@
+"""portfolio_scanner.py — Phase 3B portfolio integration for control-tower.
+
+Scans the GitHub portfolio (all repos owned by a configured user) and returns
+structured health metrics that the Enhanced Decision Desk can embed in its
+nightly issue.
+
+This module is self-contained: it uses only PyGithub (already a control-tower
+dependency) and stdlib.  It does *not* import from the portfolio-management
+repo — that repo's MCP server is the interface for interactive AI clients;
+this module is for the automated GitHub Actions workflow.
+
+Design goals:
+- Graceful degradation: if the scan fails for any reason, the caller receives
+  an empty result and the Decision Desk still posts its normal report.
+- No extra dependencies: PyGithub + stdlib only.
+- Consistent scoring: health algorithm matches portfolio-management's scorer
+  (basic depth — metrics available from the repo listing API without extra calls).
+
+Environment variables:
+    GITHUB_TOKEN      Required — also used by the rest of the workflow.
+    GITHUB_USERNAME   GitHub username to scan (default: zebadee2kk).
+    PORTFOLIO_MAX_REPOS  Max repos to include in one scan (default: 30).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from github import Github, GithubException
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_USERNAME = "zebadee2kk"
+_DEFAULT_MAX_REPOS = 30
+
+# ---------------------------------------------------------------------------
+# Health scoring constants — kept in sync with portfolio-management/src/health_scorer.py
+# ---------------------------------------------------------------------------
+_ISSUE_PENALTY_PER = 2.0
+_ISSUE_PENALTY_MAX = 40.0
+_STALE_THRESHOLD_DAYS = 30
+_STALE_PENALTY_PER_DAY = 0.5
+_STALE_PENALTY_MAX = 30.0
+_RECENT_BONUS_DAYS = 7
+_RECENT_BONUS = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RepoHealth:
+    """Health snapshot for a single repository.
+
+    Attributes:
+        name:              Full repo name (``owner/repo``).
+        description:       Repo description string.
+        open_issues:       Count of open issues.
+        days_since_update: Days since the repo was last updated.
+        health_score:      0–100 composite health score.
+        health_grade:      Letter grade derived from health_score (A–F).
+        language:          Primary language or ``None``.
+        private:           Whether the repo is private.
+        archived:          Whether the repo is archived.
+        url:               HTML URL of the repo.
+    """
+
+    name: str
+    description: str
+    open_issues: int
+    days_since_update: int
+    health_score: float
+    health_grade: str
+    language: str | None
+    private: bool
+    archived: bool
+    url: str
+
+
+@dataclass
+class PortfolioSummary:
+    """Aggregated metrics across the scanned portfolio.
+
+    Attributes:
+        total_repos:       Number of repos scanned.
+        avg_health_score:  Mean health score across all repos.
+        portfolio_grade:   Letter grade for the whole portfolio.
+        critical_count:    Repos with health_score < 40.
+        healthy_count:     Repos with health_score >= 70.
+        total_open_issues: Sum of open_issues across all repos.
+        top_repos:         Up to 5 repos sorted by health_score ascending (worst first).
+        scan_timestamp:    ISO timestamp of the scan.
+        error:             Non-empty if the scan failed entirely.
+    """
+
+    total_repos: int = 0
+    avg_health_score: float = 0.0
+    portfolio_grade: str = "N/A"
+    critical_count: int = 0
+    healthy_count: int = 0
+    total_open_issues: int = 0
+    top_repos: list[RepoHealth] = field(default_factory=list)
+    scan_timestamp: str = ""
+    error: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Health scoring (mirrors portfolio-management/src/health_scorer.py basic depth)
+# ---------------------------------------------------------------------------
+
+
+def _score(open_issues: int, days_since_update: int, is_archived: bool) -> float:
+    """Return a 0–100 health score from basic repo metrics.
+
+    Args:
+        open_issues:       Count of open issues on the repo.
+        days_since_update: Days elapsed since last update.
+        is_archived:       Whether the repo is archived.
+
+    Returns:
+        Float in [0.0, 100.0].
+    """
+    if is_archived:
+        return 0.0
+
+    score = 100.0
+    score -= min(open_issues * _ISSUE_PENALTY_PER, _ISSUE_PENALTY_MAX)
+
+    if days_since_update > _STALE_THRESHOLD_DAYS:
+        excess = days_since_update - _STALE_THRESHOLD_DAYS
+        score -= min(excess * _STALE_PENALTY_PER_DAY, _STALE_PENALTY_MAX)
+
+    if days_since_update < _RECENT_BONUS_DAYS:
+        score += _RECENT_BONUS
+
+    return round(max(0.0, min(100.0, score)), 1)
+
+
+def _grade(score: float) -> str:
+    """Convert a numeric health score to a letter grade.
+
+    Args:
+        score: Value in [0, 100].
+
+    Returns:
+        One of ``'A'``, ``'B'``, ``'C'``, ``'D'``, ``'F'``.
+    """
+    if score >= 85:
+        return "A"
+    if score >= 70:
+        return "B"
+    if score >= 55:
+        return "C"
+    if score >= 40:
+        return "D"
+    return "F"
+
+
+def _days_since(dt: datetime) -> int:
+    """Return the whole number of days between *dt* and now (UTC).
+
+    Args:
+        dt: Datetime (aware or naive — naive treated as UTC).
+
+    Returns:
+        Non-negative integer.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return max(0, (datetime.now(UTC) - dt).days)
+
+
+# ---------------------------------------------------------------------------
+# Scanner
+# ---------------------------------------------------------------------------
+
+
+class PortfolioScanner:
+    """Scans a GitHub user's repositories and computes health metrics.
+
+    Args:
+        token:     GitHub PAT.  Defaults to ``GITHUB_TOKEN`` env var.
+        username:  GitHub username to scan.  Defaults to ``GITHUB_USERNAME``
+                   env var, then ``zebadee2kk``.
+        max_repos: Maximum number of repos to include per scan.  Defaults to
+                   ``PORTFOLIO_MAX_REPOS`` env var, then 30.
+    """
+
+    def __init__(
+        self,
+        token: str | None = None,
+        username: str | None = None,
+        max_repos: int | None = None,
+    ) -> None:
+        resolved_token = token or os.getenv("GITHUB_TOKEN")
+        if not resolved_token:
+            raise ValueError(
+                "GitHub token required: pass token= or set GITHUB_TOKEN env var"
+            )
+        self._gh = Github(resolved_token)
+        self._username: str = (
+            username
+            or os.getenv("GITHUB_USERNAME")
+            or _DEFAULT_USERNAME
+        )
+        env_max = os.getenv("PORTFOLIO_MAX_REPOS")
+        self._max_repos: int = (
+            max_repos
+            if max_repos is not None
+            else (int(env_max) if env_max else _DEFAULT_MAX_REPOS)
+        )
+
+    def scan(self, include_private: bool = True) -> list[RepoHealth]:
+        """Scan repositories and return per-repo health data.
+
+        Non-fatal errors on individual repos are logged and skipped; the scan
+        continues.  If the user cannot be fetched, an empty list is returned.
+
+        Args:
+            include_private: Include private repos in the scan.
+
+        Returns:
+            List of :class:`RepoHealth` instances, sorted by health_score
+            ascending (worst first).
+        """
+        try:
+            user = self._gh.get_user(self._username)
+            repos = list(user.get_repos())
+        except GithubException as exc:
+            logger.error("Portfolio scan failed: could not list repos: %s", exc)
+            return []
+
+        if not include_private:
+            repos = [r for r in repos if not r.private]
+
+        repos = repos[: self._max_repos]
+
+        results: list[RepoHealth] = []
+        for repo in repos:
+            try:
+                health = self._repo_health(repo)
+                results.append(health)
+            except Exception as exc:  # noqa: BLE001 — per-repo, keep scanning
+                logger.warning("Skipping %s during portfolio scan: %s", repo.full_name, exc)
+
+        results.sort(key=lambda r: r.health_score)
+        logger.info(
+            "Portfolio scan complete: %d repos scanned for %s",
+            len(results),
+            self._username,
+        )
+        return results
+
+    def summarise(self, repos: list[RepoHealth]) -> PortfolioSummary:
+        """Derive aggregate statistics from a list of repo health snapshots.
+
+        Args:
+            repos: Output of :meth:`scan`.
+
+        Returns:
+            A :class:`PortfolioSummary` describing the whole portfolio.
+        """
+        if not repos:
+            return PortfolioSummary(scan_timestamp=datetime.now(UTC).isoformat())
+
+        total = len(repos)
+        avg = round(sum(r.health_score for r in repos) / total, 1)
+        critical = sum(1 for r in repos if r.health_score < 40)
+        healthy = sum(1 for r in repos if r.health_score >= 70)
+        total_issues = sum(r.open_issues for r in repos)
+
+        # Worst 5 repos (already sorted ascending by scan())
+        top_repos = repos[:5]
+
+        return PortfolioSummary(
+            total_repos=total,
+            avg_health_score=avg,
+            portfolio_grade=_grade(avg),
+            critical_count=critical,
+            healthy_count=healthy,
+            total_open_issues=total_issues,
+            top_repos=top_repos,
+            scan_timestamp=datetime.now(UTC).isoformat(),
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _repo_health(self, repo: Any) -> RepoHealth:
+        """Convert a PyGithub Repository object into a :class:`RepoHealth`."""
+        days = _days_since(repo.updated_at)
+        score = _score(repo.open_issues_count, days, repo.archived)
+        return RepoHealth(
+            name=repo.full_name,
+            description=repo.description or "",
+            open_issues=repo.open_issues_count,
+            days_since_update=days,
+            health_score=score,
+            health_grade=_grade(score),
+            language=repo.language,
+            private=repo.private,
+            archived=repo.archived,
+            url=repo.html_url,
+        )

--- a/src/run_enhanced_desk.py
+++ b/src/run_enhanced_desk.py
@@ -33,6 +33,7 @@ load_dotenv(os.path.expanduser("~/.env"), override=True)
 from src.ai_analysis import score_issues_batch  # noqa: E402
 from src.decision_desk import DecisionDesk  # noqa: E402
 from src.integrations.cost_tracker import CostTrackerClient  # noqa: E402
+from src.integrations.portfolio_scanner import PortfolioScanner, PortfolioSummary  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -48,6 +49,58 @@ _AI_SCORE_LIMIT = 15
 # ---------------------------------------------------------------------------
 # Enhanced Markdown renderer
 # ---------------------------------------------------------------------------
+
+def _render_portfolio_section(summary: PortfolioSummary) -> list[str]:
+    """Render the portfolio health summary as Markdown lines.
+
+    Returns an empty list if the scan failed or produced no repos.
+    """
+    if summary.error or summary.total_repos == 0:
+        return []
+
+    grade_emoji = {"A": "🟢", "B": "🟡", "C": "🟠", "D": "🔴", "F": "🔴"}.get(
+        summary.portfolio_grade, "⚪"
+    )
+
+    lines = [
+        "## 📊 Portfolio Health",
+        "",
+        "| Repos | Avg Score | Grade | Healthy | Critical | Open Issues |",
+        "|-------|-----------|-------|---------|----------|-------------|",
+        (
+            f"| {summary.total_repos} "
+            f"| {summary.avg_health_score} "
+            f"| {grade_emoji} **{summary.portfolio_grade}** "
+            f"| {summary.healthy_count} "
+            f"| {summary.critical_count} "
+            f"| {summary.total_open_issues} |"
+        ),
+        "",
+    ]
+
+    if summary.top_repos:
+        lines += ["**⚠️ Repos needing attention** *(lowest health scores)*", ""]
+        for repo in summary.top_repos:
+            grade_e = {"A": "🟢", "B": "🟡", "C": "🟠", "D": "🔴", "F": "🔴"}.get(
+                repo.health_grade, "⚪"
+            )
+            archived_tag = " `archived`" if repo.archived else ""
+            private_tag = " `private`" if repo.private else ""
+            lines.append(
+                f"- [{repo.name}]({repo.url}){archived_tag}{private_tag} — "
+                f"**{repo.health_score}** {grade_e} {repo.health_grade} "
+                f"({repo.open_issues} issues, {repo.days_since_update}d stale)"
+            )
+        lines.append("")
+
+    lines += [
+        f"*Scanned {summary.total_repos} repos at {summary.scan_timestamp[:16]} UTC*",
+        "",
+        "---",
+        "",
+    ]
+    return lines
+
 
 def _render_ai_section(scored: list[dict[str, Any]]) -> list[str]:
     """Render the AI scoring table as Markdown."""
@@ -85,20 +138,36 @@ def render_enhanced_report(
     report: dict[str, Any],
     desk: DecisionDesk,
     scored: list[dict[str, Any]],
+    portfolio: PortfolioSummary | None = None,
 ) -> str:
-    """
-    Combine the standard Decision Desk Markdown with the AI scoring table.
-    """
-    # Start with the standard report body
-    base_md = desk.render_markdown(report)
+    """Combine portfolio summary, standard Decision Desk, and AI scoring table.
 
-    # Append AI section
+    Args:
+        report:    Structured report dict from :meth:`DecisionDesk.build_report`.
+        desk:      :class:`DecisionDesk` instance (for Markdown rendering).
+        scored:    AI-scored issue dicts from :func:`score_issues_batch`.
+        portfolio: Optional portfolio health summary; omitted if ``None``.
+
+    Returns:
+        Full Markdown string ready to post as a GitHub issue body.
+    """
+    sections: list[str] = []
+
+    # Portfolio section (prepended — most strategic view first)
+    if portfolio is not None:
+        portfolio_lines = _render_portfolio_section(portfolio)
+        if portfolio_lines:
+            sections.append("\n".join(portfolio_lines))
+
+    # Standard Decision Desk triage
+    sections.append(desk.render_markdown(report))
+
+    # AI scoring table
     ai_lines = _render_ai_section(scored)
     if ai_lines:
-        ai_block = "\n".join(["", "---", ""] + ai_lines)
-        return base_md + ai_block
+        sections.append("\n".join(["", "---", ""] + ai_lines))
 
-    return base_md
+    return "\n".join(sections)
 
 
 # ---------------------------------------------------------------------------
@@ -114,6 +183,21 @@ def main() -> None:
         sys.exit(1)
 
     logger.info("Starting Enhanced Decision Desk for %s", repo_name)
+
+    # --- Portfolio scan (Phase 3B) ---
+    portfolio: PortfolioSummary | None = None
+    try:
+        scanner = PortfolioScanner(token=token)
+        repos = scanner.scan()
+        portfolio = scanner.summarise(repos)
+        logger.info(
+            "Portfolio scan: %d repos, avg score %.1f (%s)",
+            portfolio.total_repos,
+            portfolio.avg_health_score,
+            portfolio.portfolio_grade,
+        )
+    except Exception as exc:  # noqa: BLE001 — portfolio is bonus; never block the main report
+        logger.warning("Portfolio scan skipped: %s", exc)
 
     # --- Build report ---
     desk = DecisionDesk(Github(token), repo_name)
@@ -147,7 +231,7 @@ def main() -> None:
         scored = []
 
     # --- Render enhanced report ---
-    body = render_enhanced_report(report, desk, scored)
+    body = render_enhanced_report(report, desk, scored, portfolio=portfolio)
 
     # --- Post to GitHub ---
     new_issue = desk.post_report(body)

--- a/tests/unit/test_portfolio_scanner.py
+++ b/tests/unit/test_portfolio_scanner.py
@@ -1,0 +1,446 @@
+"""Unit tests for src/integrations/portfolio_scanner.py."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from github import GithubException
+
+from src.integrations.portfolio_scanner import (
+    PortfolioScanner,
+    PortfolioSummary,
+    RepoHealth,
+    _days_since,
+    _grade,
+    _score,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_repo(
+    full_name: str = "zebadee2kk/test-repo",
+    open_issues: int = 2,
+    days_old: int = 5,
+    archived: bool = False,
+    private: bool = False,
+    language: str = "Python",
+    description: str = "A test repo",
+    html_url: str = "https://github.com/zebadee2kk/test-repo",
+) -> MagicMock:
+    repo = MagicMock()
+    repo.full_name = full_name
+    repo.description = description
+    repo.open_issues_count = open_issues
+    repo.updated_at = datetime.now(UTC) - timedelta(days=days_old)
+    repo.archived = archived
+    repo.private = private
+    repo.language = language
+    repo.html_url = html_url
+    return repo
+
+
+def _make_scanner(mock_github: MagicMock, token: str = "tok") -> PortfolioScanner:  # noqa: S107
+    with patch("src.integrations.portfolio_scanner.Github", return_value=mock_github):
+        return PortfolioScanner(token=token)
+
+
+# ---------------------------------------------------------------------------
+# _score
+# ---------------------------------------------------------------------------
+
+
+class TestScore:
+    def test_archived_is_zero(self):
+        assert _score(0, 0, is_archived=True) == 0.0
+
+    def test_no_issues_recent(self):
+        # 100 + 10 bonus = 110 → capped at 100
+        assert _score(0, 1, is_archived=False) == 100.0
+
+    def test_issues_penalty(self):
+        # 100 - (5 * 2) = 90, days=20 no stale, no bonus
+        assert _score(5, 20, is_archived=False) == 90.0
+
+    def test_issue_penalty_capped(self):
+        # 100 - 40 (max) = 60
+        assert _score(100, 20, is_archived=False) == 60.0
+
+    def test_stale_penalty(self):
+        # 100 - (50-30)*0.5 = 90
+        assert _score(0, 50, is_archived=False) == 90.0
+
+    def test_stale_penalty_capped(self):
+        # 100 - 30 (max stale) = 70
+        assert _score(0, 200, is_archived=False) == 70.0
+
+    def test_recent_bonus(self):
+        # 100 - 10 (5 issues) + 10 (recent) = 100
+        assert _score(5, 3, is_archived=False) == 100.0
+
+    def test_score_floor_zero(self):
+        assert _score(1000, 1000, is_archived=False) >= 0.0
+
+    def test_score_ceiling_100(self):
+        assert _score(0, 0, is_archived=False) <= 100.0
+
+    def test_returns_float(self):
+        assert isinstance(_score(1, 1, is_archived=False), float)
+
+
+# ---------------------------------------------------------------------------
+# _grade
+# ---------------------------------------------------------------------------
+
+
+class TestGrade:
+    @pytest.mark.parametrize(
+        "score,expected",
+        [
+            (100.0, "A"), (85.0, "A"), (84.9, "B"), (70.0, "B"),
+            (69.9, "C"), (55.0, "C"), (54.9, "D"), (40.0, "D"),
+            (39.9, "F"), (0.0, "F"),
+        ],
+    )
+    def test_boundaries(self, score, expected):
+        assert _grade(score) == expected
+
+
+# ---------------------------------------------------------------------------
+# _days_since
+# ---------------------------------------------------------------------------
+
+
+class TestDaysSince:
+    def test_now_is_zero(self):
+        assert _days_since(datetime.now(UTC)) == 0
+
+    def test_yesterday_is_one(self):
+        assert _days_since(datetime.now(UTC) - timedelta(days=1)) == 1
+
+    def test_naive_datetime_treated_as_utc(self):
+        naive = datetime.now().replace(tzinfo=None) - timedelta(days=3)
+        assert _days_since(naive) >= 2
+
+
+# ---------------------------------------------------------------------------
+# PortfolioScanner construction
+# ---------------------------------------------------------------------------
+
+
+class TestPortfolioScannerInit:
+    def test_raises_without_token(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        with pytest.raises(ValueError, match="GitHub token required"):
+            PortfolioScanner(token=None)
+
+    def test_uses_env_token(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "env-tok")
+        with patch("src.integrations.portfolio_scanner.Github") as mock_gh:
+            PortfolioScanner()
+            mock_gh.assert_called_once_with("env-tok")
+
+    def test_default_username(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_USERNAME", raising=False)
+        with patch("src.integrations.portfolio_scanner.Github"):
+            s = PortfolioScanner(token="tok")
+        assert s._username == "zebadee2kk"
+
+    def test_env_username(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_USERNAME", "richco")
+        with patch("src.integrations.portfolio_scanner.Github"):
+            s = PortfolioScanner(token="tok")
+        assert s._username == "richco"
+
+    def test_explicit_username(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_USERNAME", raising=False)
+        with patch("src.integrations.portfolio_scanner.Github"):
+            s = PortfolioScanner(token="tok", username="custom")
+        assert s._username == "custom"
+
+    def test_default_max_repos(self, monkeypatch):
+        monkeypatch.delenv("PORTFOLIO_MAX_REPOS", raising=False)
+        with patch("src.integrations.portfolio_scanner.Github"):
+            s = PortfolioScanner(token="tok")
+        assert s._max_repos == 30
+
+    def test_env_max_repos(self, monkeypatch):
+        monkeypatch.setenv("PORTFOLIO_MAX_REPOS", "10")
+        with patch("src.integrations.portfolio_scanner.Github"):
+            s = PortfolioScanner(token="tok")
+        assert s._max_repos == 10
+
+    def test_explicit_max_repos(self):
+        with patch("src.integrations.portfolio_scanner.Github"):
+            s = PortfolioScanner(token="tok", max_repos=5)
+        assert s._max_repos == 5
+
+
+# ---------------------------------------------------------------------------
+# PortfolioScanner.scan()
+# ---------------------------------------------------------------------------
+
+
+class TestPortfolioScannerScan:
+    def _mock_github_with_repos(self, repos):
+        mock_gh = MagicMock()
+        mock_user = MagicMock()
+        mock_user.get_repos.return_value = repos
+        mock_gh.get_user.return_value = mock_user
+        return mock_gh
+
+    def test_returns_list(self):
+        mock_gh = self._mock_github_with_repos([_make_mock_repo()])
+        scanner = _make_scanner(mock_gh)
+        result = scanner.scan()
+        assert isinstance(result, list)
+
+    def test_returns_repo_health_instances(self):
+        mock_gh = self._mock_github_with_repos([_make_mock_repo()])
+        scanner = _make_scanner(mock_gh)
+        result = scanner.scan()
+        assert all(isinstance(r, RepoHealth) for r in result)
+
+    def test_sorted_worst_first(self):
+        repos = [
+            _make_mock_repo("z/healthy", open_issues=0, days_old=1),
+            _make_mock_repo("z/sick", open_issues=20, days_old=90),
+        ]
+        mock_gh = self._mock_github_with_repos(repos)
+        scanner = _make_scanner(mock_gh)
+        result = scanner.scan()
+        assert result[0].health_score <= result[-1].health_score
+
+    def test_filters_private_when_requested(self):
+        public = _make_mock_repo("z/public", private=False)
+        private = _make_mock_repo("z/private", private=True)
+        mock_gh = self._mock_github_with_repos([public, private])
+        scanner = _make_scanner(mock_gh)
+        result = scanner.scan(include_private=False)
+        assert all(not r.private for r in result)
+
+    def test_github_error_returns_empty(self):
+        mock_gh = MagicMock()
+        mock_gh.get_user.side_effect = GithubException(403, "Forbidden")
+        scanner = _make_scanner(mock_gh)
+        assert scanner.scan() == []
+
+    def test_per_repo_error_skipped(self):
+        bad_repo = MagicMock()
+        bad_repo.full_name = "z/bad"
+        type(bad_repo).updated_at = property(
+            fget=lambda self: (_ for _ in ()).throw(Exception("API fail"))
+        )
+        good_repo = _make_mock_repo("z/good")
+        mock_gh = self._mock_github_with_repos([bad_repo, good_repo])
+        scanner = _make_scanner(mock_gh)
+        result = scanner.scan()
+        # Only the good repo makes it through
+        assert len(result) == 1
+        assert result[0].name == "z/good"
+
+    def test_respects_max_repos_limit(self):
+        repos = [_make_mock_repo(f"z/repo-{i}") for i in range(20)]
+        mock_gh = self._mock_github_with_repos(repos)
+        with patch("src.integrations.portfolio_scanner.Github", return_value=mock_gh):
+            scanner = PortfolioScanner(token="tok", max_repos=5)
+        result = scanner.scan()
+        assert len(result) <= 5
+
+    def test_archived_repo_scores_zero(self):
+        repo = _make_mock_repo(archived=True)
+        mock_gh = self._mock_github_with_repos([repo])
+        scanner = _make_scanner(mock_gh)
+        result = scanner.scan()
+        assert result[0].health_score == 0.0
+        assert result[0].health_grade == "F"
+
+    def test_repo_health_fields_populated(self):
+        repo = _make_mock_repo(
+            full_name="z/myrepo",
+            open_issues=3,
+            days_old=10,
+            language="Python",
+            description="desc",
+            html_url="https://github.com/z/myrepo",
+            private=False,
+            archived=False,
+        )
+        mock_gh = self._mock_github_with_repos([repo])
+        scanner = _make_scanner(mock_gh)
+        result = scanner.scan()
+        r = result[0]
+        assert r.name == "z/myrepo"
+        assert r.open_issues == 3
+        assert r.language == "Python"
+        assert r.description == "desc"
+        assert r.url == "https://github.com/z/myrepo"
+        assert not r.private
+        assert not r.archived
+
+
+# ---------------------------------------------------------------------------
+# PortfolioScanner.summarise()
+# ---------------------------------------------------------------------------
+
+
+class TestPortfolioScannerSummarise:
+    def _make_health(self, score: float, open_issues: int = 0) -> RepoHealth:
+        return RepoHealth(
+            name=f"z/repo-{int(score)}",
+            description="",
+            open_issues=open_issues,
+            days_since_update=10,
+            health_score=score,
+            health_grade=_grade(score),
+            language=None,
+            private=False,
+            archived=False,
+            url="https://github.com/z/repo",
+        )
+
+    def test_empty_list_returns_default_summary(self):
+        with patch("src.integrations.portfolio_scanner.Github"):
+            scanner = PortfolioScanner(token="tok")
+        summary = scanner.summarise([])
+        assert summary.total_repos == 0
+        assert summary.portfolio_grade == "N/A"
+
+    def test_total_repos_count(self):
+        with patch("src.integrations.portfolio_scanner.Github"):
+            scanner = PortfolioScanner(token="tok")
+        repos = [self._make_health(80.0), self._make_health(60.0)]
+        summary = scanner.summarise(repos)
+        assert summary.total_repos == 2
+
+    def test_avg_health_score(self):
+        with patch("src.integrations.portfolio_scanner.Github"):
+            scanner = PortfolioScanner(token="tok")
+        repos = [self._make_health(80.0), self._make_health(60.0)]
+        summary = scanner.summarise(repos)
+        assert summary.avg_health_score == 70.0
+
+    def test_portfolio_grade_derived_from_avg(self):
+        with patch("src.integrations.portfolio_scanner.Github"):
+            scanner = PortfolioScanner(token="tok")
+        repos = [self._make_health(80.0), self._make_health(60.0)]  # avg=70 → B
+        summary = scanner.summarise(repos)
+        assert summary.portfolio_grade == "B"
+
+    def test_critical_count(self):
+        with patch("src.integrations.portfolio_scanner.Github"):
+            scanner = PortfolioScanner(token="tok")
+        repos = [self._make_health(30.0), self._make_health(80.0)]
+        summary = scanner.summarise(repos)
+        assert summary.critical_count == 1
+
+    def test_healthy_count(self):
+        with patch("src.integrations.portfolio_scanner.Github"):
+            scanner = PortfolioScanner(token="tok")
+        repos = [self._make_health(75.0), self._make_health(30.0)]
+        summary = scanner.summarise(repos)
+        assert summary.healthy_count == 1
+
+    def test_total_open_issues(self):
+        with patch("src.integrations.portfolio_scanner.Github"):
+            scanner = PortfolioScanner(token="tok")
+        repos = [self._make_health(80.0, open_issues=3), self._make_health(60.0, open_issues=7)]
+        summary = scanner.summarise(repos)
+        assert summary.total_open_issues == 10
+
+    def test_top_repos_max_five(self):
+        with patch("src.integrations.portfolio_scanner.Github"):
+            scanner = PortfolioScanner(token="tok")
+        repos = [self._make_health(float(s)) for s in range(10, 90, 10)]
+        summary = scanner.summarise(repos)
+        assert len(summary.top_repos) <= 5
+
+    def test_top_repos_are_worst(self):
+        with patch("src.integrations.portfolio_scanner.Github"):
+            scanner = PortfolioScanner(token="tok")
+        repos = [self._make_health(90.0), self._make_health(20.0), self._make_health(50.0)]
+        summary = scanner.summarise(repos)
+        # top_repos should include the worst (20.0)
+        scores = [r.health_score for r in summary.top_repos]
+        assert 20.0 in scores
+
+    def test_scan_timestamp_is_set(self):
+        with patch("src.integrations.portfolio_scanner.Github"):
+            scanner = PortfolioScanner(token="tok")
+        summary = scanner.summarise([self._make_health(80.0)])
+        assert summary.scan_timestamp != ""
+
+
+# ---------------------------------------------------------------------------
+# _render_portfolio_section integration
+# ---------------------------------------------------------------------------
+
+
+class TestRenderPortfolioSection:
+    """Test the Markdown renderer in run_enhanced_desk for portfolio data."""
+
+    def _make_summary(self, **kwargs) -> PortfolioSummary:
+        defaults = dict(
+            total_repos=10,
+            avg_health_score=72.0,
+            portfolio_grade="B",
+            critical_count=1,
+            healthy_count=7,
+            total_open_issues=23,
+            top_repos=[],
+            scan_timestamp="2026-03-08T21:10:00+00:00",
+            error="",
+        )
+        defaults.update(kwargs)
+        return PortfolioSummary(**defaults)
+
+    def test_empty_on_error(self):
+        from src.run_enhanced_desk import _render_portfolio_section
+        summary = self._make_summary(error="scan failed")
+        assert _render_portfolio_section(summary) == []
+
+    def test_empty_when_no_repos(self):
+        from src.run_enhanced_desk import _render_portfolio_section
+        summary = self._make_summary(total_repos=0)
+        assert _render_portfolio_section(summary) == []
+
+    def test_contains_repo_count(self):
+        from src.run_enhanced_desk import _render_portfolio_section
+        summary = self._make_summary()
+        md = "\n".join(_render_portfolio_section(summary))
+        assert "10" in md
+
+    def test_contains_grade(self):
+        from src.run_enhanced_desk import _render_portfolio_section
+        summary = self._make_summary(portfolio_grade="B")
+        md = "\n".join(_render_portfolio_section(summary))
+        assert "B" in md
+
+    def test_contains_portfolio_health_header(self):
+        from src.run_enhanced_desk import _render_portfolio_section
+        summary = self._make_summary()
+        md = "\n".join(_render_portfolio_section(summary))
+        assert "Portfolio Health" in md
+
+    def test_attention_repos_listed(self):
+        from src.run_enhanced_desk import _render_portfolio_section
+        repo = RepoHealth(
+            name="z/bad-repo",
+            description="",
+            open_issues=5,
+            days_since_update=60,
+            health_score=20.0,
+            health_grade="F",
+            language="Python",
+            private=False,
+            archived=False,
+            url="https://github.com/z/bad-repo",
+        )
+        summary = self._make_summary(top_repos=[repo])
+        md = "\n".join(_render_portfolio_section(summary))
+        assert "bad-repo" in md
+        assert "20.0" in md


### PR DESCRIPTION
## Summary

Phase 3B Part 2: surfaces GitHub portfolio health data at the top of each nightly Enhanced Decision Desk report.

- **`src/integrations/portfolio_scanner.py`** — standalone `PortfolioScanner` class (no cross-repo import). Uses PyGithub directly. `RepoHealth` and `PortfolioSummary` dataclasses. Health scoring mirrors the portfolio-management MCP server: 0–100 score with issue penalty (2pts/issue, max 40), staleness penalty (0.5pts/day over 30 days, max 30), recent-activity bonus (+10 if updated <7 days), archived repos score 0. Letter grades A–F. Per-repo errors are caught and skipped.
- **`src/run_enhanced_desk.py`** — `_render_portfolio_section()` renders a markdown health table + worst-5 attention repos. `render_enhanced_report()` gains an optional `portfolio` param. `main()` runs the scan in a broad `try/except` so any failure never blocks the core Decision Desk report (graceful degradation).
- **`tests/unit/test_portfolio_scanner.py`** — 56 new tests covering scoring, grading, `_days_since`, scanner init/scan/summarise, and the render helper.

## Test results

```
140 passed in 1.04s
Coverage: 84% overall (>=80% threshold)
portfolio_scanner.py: 100% coverage
ruff: All checks passed
```

## Related

- Companion PR merged in portfolio-management: `feat/phase-3b-scanner-mcp-server` (FastMCP server with 4 tools, 82 tests, 98% coverage)
- Phase 3B architecture: portfolio-management hosts MCP servers for interactive AI clients (Claude Desktop); control-tower uses direct PyGithub for GitHub Actions compatibility

## Test plan

- [ ] Review `src/integrations/portfolio_scanner.py` — scoring algorithm, graceful error handling
- [ ] Review `src/run_enhanced_desk.py` diff — portfolio section render, graceful degradation in `main()`
- [ ] Confirm CI passes on this PR
- [ ] Wait for nightly workflow run (21:10 UTC) to verify portfolio section appears in posted issue

Generated with Claude