### PR TITLE
docs: add source lifecycle status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Control Tower
 
+## Repository status
+
+Active internal development for this code has been consolidated into `zebadee2kk/agent-toolkit/control-tower/`.
+
+This public source repository is retained as a public reference unless Richard separately approves a different public-source lifecycle action. Do not archive this public repo automatically.
+
+
 **AI-Orchestrated Project Governance Platform**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,16 @@
+# control-tower status
+
+Status: consolidated to `zebadee2kk/agent-toolkit/control-tower/`.
+
+Source repository: `zebadee2kk/control-tower`
+Canonical target: `zebadee2kk/agent-toolkit/control-tower/`
+
+## Import posture
+
+- Target import has merged.
+- Source history was not imported as part of the target consolidation.
+- Source repository remains available at this lifecycle stage.
+
+## Public-source posture
+
+This is a public repository. Retain it as a public reference unless Richard separately approves another public-source lifecycle action. Do not archive automatically.


### PR DESCRIPTION
## Summary
- Adds README lifecycle notice and STATUS.md for Phase 8 Fast Lane issue 46.
- Records canonical target: `zebadee2kk/agent-toolkit/control-tower/`
- Preserves source repository availability at this lifecycle stage.

## Validation
- git diff --cached --check: PASS
- docs-scope check: PASS
- credential-shaped literal scan over changed files: PASS

## Boundaries
- No archive, delete, rename, transfer, visibility/settings/secrets/branch-protection/labels/topics changes.
- No source history rewrite.
- No secret values exposed.

Refs zebadee2kk/portfolio-management#46