### PR TITLE
docs: clarify internal canonical status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 ## Repository status
 
-Active internal development for this code has been consolidated into `zebadee2kk/agent-toolkit/control-tower/`.
+The internal canonical copy for active WorkOS development now lives at `zebadee2kk/agent-toolkit/control-tower/`.
 
-This public source repository is retained as a public reference unless Richard separately approves a different public-source lifecycle action. Do not archive this public repo automatically.
+This public repository remains public and available as a reference source. Do not archive it, delete its content, or change repository settings unless Richard separately approves a different lifecycle action.
 
 
 **AI-Orchestrated Project Governance Platform**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-![Status](https://img.shields.io/badge/status-active_development-blue.svg)
+![Status](https://img.shields.io/badge/status-public_reference-blue.svg)
 
 ---
 
@@ -67,7 +67,7 @@ This is what responsible AI-assisted operations looks like in practice.
 
 ## Status
 
-Active development. Decision Desk, cost tracking, label automation, and WIP limits are operational. Full 16-repo portfolio view and cross-repo dependency tracking are in active build.
+Public reference status. Internal canonical development continues in `zebadee2kk/agent-toolkit/control-tower/`; this repository remains public and should not be archived or deleted without separate approval.
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,16 +1,16 @@
 # control-tower status
 
-Status: consolidated to `zebadee2kk/agent-toolkit/control-tower/`.
+Status: public reference repository with an internal canonical copy at `zebadee2kk/agent-toolkit/control-tower/`.
 
 Source repository: `zebadee2kk/control-tower`
-Canonical target: `zebadee2kk/agent-toolkit/control-tower/`
+Internal canonical copy: `zebadee2kk/agent-toolkit/control-tower/`
 
 ## Import posture
 
 - Target import has merged.
 - Source history was not imported as part of the target consolidation.
-- Source repository remains available at this lifecycle stage.
+- Source repository remains public and available at this lifecycle stage.
 
 ## Public-source posture
 
-This is a public repository. Retain it as a public reference unless Richard separately approves another public-source lifecycle action. Do not archive automatically.
+This is a public repository. Keep it public and retain it as a public reference unless Richard separately approves another public-source lifecycle action. Do not archive it, delete content, or change repository settings as part of this status update.


### PR DESCRIPTION
## Summary
- Updates `README.md` to show this public repository is now a public reference with the internal canonical copy at `zebadee2kk/agent-toolkit/control-tower/`.
- Updates `STATUS.md` with the same internal canonical copy and public-source posture.
- Keeps the source repository public and does not remove content.

## Validation
- `git diff --check`
- Credential-shaped literal scan over changed files: `README.md`, `STATUS.md`
- Docs-only check: only Markdown files changed

## WorkOS posture
- Branch created from `main`.
- No merge performed.
- No archive/delete action performed.
- No repository settings, visibility, secrets, branch protection, labels, or topics changed.
- No production deployment.
- No client, tenant, or secret data added.

## Rollback
- Revert this documentation commit if the status wording needs to be withdrawn or replaced.

Closes #196
